### PR TITLE
Stop projects by default

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,7 +6,7 @@
     "**/.git": true,
     "**/node_modules": true,
     "**/bower_components": true,
-    "**/tmp": true,
-    "**/static": true
-  }
+    "**/tmp": true
+  },
+  "exclude": ["public/static", "public/static-vscode1.42"]
 }

--- a/src/components/addProjectModals.js
+++ b/src/components/addProjectModals.js
@@ -210,7 +210,6 @@ const AddProjectModals = ({
   setModalContent,
   projectsLimit,
   addProject,
-  currentProjectId,
 }) => {
   const device = isMobileOnly ? 'mobile' : isTablet ? 'tablet' : 'computer'
   const dispatch = useDispatch()

--- a/src/components/addProjectModals.js
+++ b/src/components/addProjectModals.js
@@ -433,49 +433,6 @@ const AddProjectModals = ({
       </Modal>
 
       <Modal
-        isOpen={modalContent === 'AnotherActiveProject'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
-        width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
-        height={isMobileOnly ? '47vh' : '25vh'}
-      >
-        <ModalWrapper>
-          {isEmbed ? (
-            <Text>
-              Before starting new project you have to stop your currently
-              running project. That means you may lose all unsaved progress. Are
-              you sure you want to stop your active project?
-            </Text>
-          ) : (
-            <Text>
-              One of your projects is currently active. You have to stop it
-              before adding a new one. You can do that in your dashboard.
-            </Text>
-          )}
-          <ButtonsWrapper mobile={device}>
-            {isEmbed ? (
-              <StroveButton
-                primary
-                onClick={() => {
-                  handleStopProject()
-                  closeModal()
-                }}
-                text="Confirm"
-                padding="10px"
-                maxWidth="150px"
-              />
-            ) : (
-              <StyledLink to="/app/dashboard" primary onClick={closeModal}>
-                Ok
-              </StyledLink>
-            )}
-            <StroveButton onClick={closeModal} text="Close" />
-          </ButtonsWrapper>
-        </ModalWrapper>
-      </Modal>
-
-      <Modal
         isOpen={modalContent?.includes('TryAgainLater')}
         onRequestClose={closeModal}
         contentLabel={modalContent}

--- a/src/components/addProjectModals.js
+++ b/src/components/addProjectModals.js
@@ -1,6 +1,5 @@
 import React, { memo } from 'react'
 import styled, { keyframes, css } from 'styled-components/macro'
-import { Link } from 'react-router-dom'
 import { isMobileOnly, isTablet } from 'react-device-detect'
 import { useDispatch } from 'react-redux'
 
@@ -9,7 +8,6 @@ import Modal from './modal'
 import { Github, Gitlab, Bitbucket } from 'components/svgs'
 import { actions } from 'state'
 import StroveButton from 'components/stroveButton.js'
-import { getWindowPathName } from 'utils'
 
 const REACT_APP_GITHUB_CLIENT_ID = process.env.REACT_APP_GITHUB_CLIENT_ID
 const REACT_APP_GITLAB_CLIENT_ID = process.env.REACT_APP_GITLAB_CLIENT_ID
@@ -85,53 +83,6 @@ const StyledAnchor = styled.a`
     height: 100%;
     margin-left: 5px;
   }
-
-  :focus {
-    outline: 0;
-  }
-
-  &:disabled {
-    opacity: 0.4;
-  }
-
-  ${props =>
-    !props.disabled &&
-    css`
-      animation: ${ButtonFadeIn} 1s ease-out;
-      cursor: pointer;
-      &:hover {
-        opacity: 1;
-        transform: translateY(-3px);
-        box-shadow: 0 12px 12px -13px ${({ theme }) => theme.colors.c1};
-      }
-    `}
-`
-
-const StyledLink = styled(Link)`
-  display: flex;
-  flex-direction: row;
-  height: auto;
-  width: 100%;
-  min-width: 70px;
-  margin: 5px;
-  padding: 10px;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  background-color: ${({ primary, theme }) =>
-    primary ? theme.colors.c1 : theme.colors.c2};
-  border-width: 1px;
-  border-style: solid;
-  font-size: 0.9rem;
-  color: ${({ primary, theme }) =>
-    primary ? theme.colors.c2 : theme.colors.c1};
-  border-radius: 5px;
-  border-color: ${({ theme }) => theme.colors.c1};
-  box-shadow: 0 10px 10px -15px ${({ theme }) => theme.colors.c1};
-  text-decoration: none;
-  transition: all 0.2s ease;
-  animation: ${FadeIn} 0.5s ease-out;
-  opacity: 0.9;
 
   :focus {
     outline: 0;

--- a/src/components/addProjectModals.js
+++ b/src/components/addProjectModals.js
@@ -219,6 +219,12 @@ const AddProjectModals = ({
   }
   const isEmbed = getWindowPathName().includes('embed')
 
+  const sharedModalProps = {
+    onRequestClose: closeModal,
+    contentLabel: modalContent,
+    ariaHideApp: false,
+  }
+
   return (
     <>
       <AddEmptyProjectModal
@@ -234,11 +240,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'LoginWithGithub'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height="30vh"
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>
@@ -260,11 +264,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'LoginWithGitlab'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height="30vh"
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>
@@ -286,11 +288,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'LoginWithBitbucket'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height="30vh"
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>
@@ -312,11 +312,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'AddGithubToLogin'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height={isMobileOnly ? '37vh' : '20vh'}
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>
@@ -338,11 +336,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'AddGitlabToLogin'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height={isMobileOnly ? '37vh' : '20vh'}
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>
@@ -364,11 +360,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'AddBitbucketToLogin'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height={isMobileOnly ? '37vh' : '20vh'}
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>
@@ -391,11 +385,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'ProjectsLimitExceeded'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height={isMobileOnly ? '47vh' : '25vh'}
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>
@@ -408,11 +400,9 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent === 'TimeExceeded'}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height={isMobileOnly ? '47vh' : '25vh'}
+        {...sharedModalProps}
       >
         <ModalWrapper>
           <Text>You have exceeded the monthly editor time for free users.</Text>
@@ -434,9 +424,6 @@ const AddProjectModals = ({
 
       <Modal
         isOpen={modalContent?.includes('TryAgainLater')}
-        onRequestClose={closeModal}
-        contentLabel={modalContent}
-        ariaHideApp={false}
         width={isMobileOnly ? '70vw' : isTablet ? '50vw' : '30vw'}
         height={isMobileOnly ? '33vh' : '20vh'}
       >

--- a/src/components/addProjectModals.js
+++ b/src/components/addProjectModals.js
@@ -459,7 +459,7 @@ const AddProjectModals = ({
               <StroveButton
                 primary
                 onClick={() => {
-                  handleStopProject({ id: currentProjectId, dispatch })
+                  handleStopProject()
                   closeModal()
                 }}
                 text="Confirm"

--- a/src/components/addProjectModals.js
+++ b/src/components/addProjectModals.js
@@ -9,7 +9,7 @@ import Modal from './modal'
 import { Github, Gitlab, Bitbucket } from 'components/svgs'
 import { actions } from 'state'
 import StroveButton from 'components/stroveButton.js'
-import { getWindowPathName, handleStopProject } from 'utils'
+import { getWindowPathName } from 'utils'
 
 const REACT_APP_GITHUB_CLIENT_ID = process.env.REACT_APP_GITHUB_CLIENT_ID
 const REACT_APP_GITLAB_CLIENT_ID = process.env.REACT_APP_GITLAB_CLIENT_ID
@@ -217,7 +217,6 @@ const AddProjectModals = ({
     setModalContent(null)
     dispatch(actions.incomingProject.removeIncomingProject())
   }
-  const isEmbed = getWindowPathName().includes('embed')
 
   const sharedModalProps = {
     onRequestClose: closeModal,

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -218,7 +218,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
       />
       <StyledModal
         isOpen={
-          ((isLoading && !isAdding) || isDeleting || isStopping) &&
+          ((isLoading && !isAdding) || isDeleting) &&
           !window.location.href.includes('editor')
         }
         contentLabel="Loading"
@@ -247,6 +247,14 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
       {isStartingCollaborationProject && (
         <FullScreenLoader
           type="addingCollaborationProject"
+          isFullScreen
+          color="#0072ce"
+          queuePosition={queuePosition}
+        />
+      )}
+      {isStopping && (
+        <FullScreenLoader
+          type="stoppingProject"
           isFullScreen
           color="#0072ce"
           queuePosition={queuePosition}

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -191,7 +191,19 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
       currentProjectId &&
       currentProject?.machineId !== existingProject?.machineId
     ) {
-      handleStopProject()
+      handleStopProject({
+        onSuccess: () =>
+          createProject({
+            repoLink,
+            dispatch,
+            user,
+            setModalContent,
+            name,
+            teamId: teamIdWithProject,
+            forkedFromId,
+            type,
+          }),
+      })
       dispatch(actions.incomingProject.setProjectIsBeingStarted())
     } else if (!theSameIncomingProject && teamId) {
       createProject({

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -113,7 +113,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
       project => project.teamId === editedTeam?.id
     )
 
-    const theSameIncomingProject = repoLink === incomingProjectRepoUr
+    const theSameIncomingProject = repoLink === incomingProjectRepoUrl
 
     if (existingProject) {
       if (!currentProject) {

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -86,11 +86,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
 
     /* TODO: Find a reasonable way to approach this */
     const organizationWithProject = organization || ownedOrganizations?.[0]
-    const teamIdWithProject = type
-      ? ownedOrganizations?.[0]?.teams?.[
-          ownedOrganizations?.[0]?.teams?.length - 1
-        ]?.id
-      : teamId
+    const teamIdWithProject = teamId || editedTeam?.id
 
     let repoFromGithub
     let repoFromGitlab
@@ -217,7 +213,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
         !theSameIncomingProject prevents double crateProject cal.
         ToDO: Figure out if we can make addProject called only once.
       */
-    } else if (!theSameIncomingProject && teamId) {
+    } else if (!theSameIncomingProject && teamIdWithProject) {
       createProject({
         repoLink,
         dispatch,

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -61,8 +61,6 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
   const timeExceeded = user?.timeSpent >= 7200000000
   const ownedOrganizations = useSelector(selectors.api.getOwnedOrganizations)
 
-  console.log('editedTeam', editedTeam)
-
   /* Check if new project is embedded */
   const originDomain =
     window.location !== window.parent.location
@@ -117,11 +115,6 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
     )
     const existingProject = allExistingProjects.find(
       project => project.teamId === editedTeam?.id
-      /* This should not be necessary for for some reason,
-        edited team is sometimes not initialized before this place is called
-        ToDo: Find a reason why this doesnt work and fix actions/selectors.
-        */
-      // project.teamId === teamIdWithProject
     )
 
     const theSameIncomingProject = repoLink === incomingProjectRepoUrl

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -77,7 +77,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
     }
   }
 
-  const addProject = async ({ link, name, teamId, forkedFromId }) => {
+  const addProject = ({ link, name, teamId, forkedFromId }) => {
     let repoLink
     let repoProvider
 

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -55,7 +55,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
   )
   const currentProjectId = currentProject?.id
   const queuePosition = useSelector(selectors.api.getQueuePosition)
-  /* Decide what to do about the projects limit */
+  /* ToDO: Decide what to do about the projects limit */
   const projectsLimit = 2000000
   // ToDO: Bring this back to reasonable value once we have a good time spent indicator
   const timeExceeded = user?.timeSpent >= 7200000000

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -178,6 +178,9 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
     } else if (projects && projects.length >= projectsLimit) {
       setModalContent('ProjectsLimitExceeded')
       dispatch(actions.incomingProject.removeIncomingProject())
+      /*
+        Check if user is not has a project running and if it's not the same one. 
+      */
     } else if (
       currentProjectId &&
       currentProject?.machineId !== existingProject?.machineId

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -8,6 +8,7 @@ import {
   getRepoProvider,
   changeRepoLinkFromSshToHttps,
   mutation,
+  handleStopProject,
 } from 'utils'
 import { CONTINUE_PROJECT } from 'queries'
 import { actions, selectors } from 'state'
@@ -190,7 +191,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
       currentProjectId &&
       currentProject?.machineId !== existingProject?.machineId
     ) {
-      setModalContent('AnotherActiveProject')
+      handleStopProject()
       dispatch(actions.incomingProject.setProjectIsBeingStarted())
     } else if (!theSameIncomingProject && teamId) {
       createProject({

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -119,6 +119,19 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
 
     const theSameIncomingProject = repoLink === incomingProjectRepoUrl
 
+    console.log(
+      'theSameIncomingProject',
+      theSameIncomingProject,
+      'repoLink',
+      repoLink,
+      'incomingProjectRepoUrl',
+      incomingProjectRepoUrl,
+      'existingProject',
+      existingProject,
+      'teamId',
+      teamId
+    )
+
     if (existingProject) {
       if (!currentProject) {
         dispatch(actions.incomingProject.setProjectIsBeingStarted())
@@ -199,7 +212,11 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
             type,
           }),
       })
-      dispatch(actions.incomingProject.setProjectIsBeingStarted())
+      /*
+        AddProjectProvider is called 2 times for some reason.
+        !theSameIncomingProject prevents double crateProject cal.
+        ToDO: Figure out if we can make addProject called only once.
+      */
     } else if (!theSameIncomingProject && teamId) {
       createProject({
         repoLink,

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -113,20 +113,7 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
       project => project.teamId === editedTeam?.id
     )
 
-    const theSameIncomingProject = repoLink === incomingProjectRepoUrl
-
-    console.log(
-      'theSameIncomingProject',
-      theSameIncomingProject,
-      'repoLink',
-      repoLink,
-      'incomingProjectRepoUrl',
-      incomingProjectRepoUrl,
-      'existingProject',
-      existingProject,
-      'teamId',
-      teamId
-    )
+    const theSameIncomingProject = repoLink === incomingProjectRepoUr
 
     if (existingProject) {
       if (!currentProject) {

--- a/src/components/addProjectProvider.js
+++ b/src/components/addProjectProvider.js
@@ -61,6 +61,8 @@ const AddProjectProvider = ({ children, history, teamId, organization }) => {
   const timeExceeded = user?.timeSpent >= 7200000000
   const ownedOrganizations = useSelector(selectors.api.getOwnedOrganizations)
 
+  console.log('editedTeam', editedTeam)
+
   /* Check if new project is embedded */
   const originDomain =
     window.location !== window.parent.location

--- a/src/components/fullScreenLoader.js
+++ b/src/components/fullScreenLoader.js
@@ -101,6 +101,7 @@ const Loader = ({ type = 'addProject', ...props }) => {
       'Reserving resources',
       'Joining liveshare',
     ],
+    stoppingProject: ['Stopping current project'],
   }
 
   useInterval(

--- a/src/components/getStarted.js
+++ b/src/components/getStarted.js
@@ -90,8 +90,6 @@ const GetStarted = ({ addProject, teamId }) => {
   const handleClose = () => setAddProjectModalOpen(false)
   const currentProject = useSelector(selectors.api.getCurrentProject)
 
-  console.log('currentProject', currentProject)
-
   return (
     <AddProjectWrapper mobile={isMobile}>
       {currentProject ? (

--- a/src/components/header/dashboardLink.js
+++ b/src/components/header/dashboardLink.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import styled, { keyframes } from 'styled-components/macro'
 import { isMobileOnly } from 'react-device-detect'
+import { getWindowPathName } from 'utils'
 
 import { selectors } from 'state'
 import { Dashboard } from 'components/svgs'
@@ -57,10 +58,11 @@ const LinkWrapper = styled.div`
 
 const DashboardLink = props => {
   const token = useSelector(selectors.getToken)
+  const isEmbed = getWindowPathName().includes('/embed')
 
   return (
     <>
-      {token && !props.isEmbed && (
+      {token && !isEmbed && (
         <LinkWrapper {...props}>
           <StyledLink to="/app/dashboard" {...props}>
             {isMobileOnly ? (

--- a/src/pages/dashboard/dashboard.js
+++ b/src/pages/dashboard/dashboard.js
@@ -727,7 +727,7 @@ const Dashboard = ({ history }) => {
   }
 
   const handleStopClick = id => {
-    handleStopProject({ id, dispatch })
+    handleStopProject({ id })
   }
 
   const handleLeaveClick = team => {

--- a/src/pages/dashboard/dashboard.js
+++ b/src/pages/dashboard/dashboard.js
@@ -108,8 +108,6 @@ const Dashboard = ({ history }) => {
   const [leaderOptions, setLeaderOptions] = useState()
   const [newOwnerSelect, setNewOwnerSelect] = useState('')
   const [warningModal, setWarningModal] = useState(emptyWarningModalContent)
-  const currentProject = useSelector(selectors.api.getCurrentProject)
-  const currentProjectId = currentProject?.id
   const createTeamError = useSelector(selectors.api.getError('createTeam'))
 
   const setEditedOrganization = ({ team }) => {
@@ -726,10 +724,6 @@ const Dashboard = ({ history }) => {
     setSettingsModal(true)
   }
 
-  const handleStopClick = id => {
-    handleStopProject({ id })
-  }
-
   const handleLeaveClick = team => {
     setEditedOrganization({ team })
     setWarningModal({
@@ -793,7 +787,7 @@ const Dashboard = ({ history }) => {
         <ModalButton
           isPrimary
           onClick={() => {
-            handleStopClick(currentProjectId)
+            handleStopProject()
             setStopModal(false)
           }}
           text="Confirm"

--- a/src/pages/dashboard/projects.js
+++ b/src/pages/dashboard/projects.js
@@ -139,10 +139,6 @@ const Projects = ({
     )
   }
 
-  const handleStopClick = id => {
-    handleStopProject({ id })
-  }
-
   const closeModal = () => {
     setProjectToDelete(null)
     setModalVisible(false)
@@ -274,7 +270,7 @@ const Projects = ({
                           onClick={() => {
                             project.startedCollaborationFromId
                               ? handleStopLiveshareClick({ project })
-                              : handleStopClick(project.id)
+                              : handleStopProject()
                           }}
                         >
                           <IconDescription>Stop</IconDescription>
@@ -504,7 +500,7 @@ const Projects = ({
         <ModalButton
           isPrimary
           onClick={() => {
-            handleStopClick(currentProjectId)
+            handleStopProject()
             setStopModal(false)
           }}
           text="Confirm"

--- a/src/pages/dashboard/projects.js
+++ b/src/pages/dashboard/projects.js
@@ -113,17 +113,6 @@ const Projects = ({
     return setStopModal(true)
   }
 
-  const handleStopLiveshareClick = ({ project }) => {
-    dispatch(
-      mutation({
-        name: 'stopLiveShare',
-        mutation: STOP_LIVE_SHARE,
-        variables: { projectId: project.id },
-        onSuccessDispatch: updateOrganizations,
-      })
-    )
-  }
-
   const handleDeleteClick = id => {
     dispatch(
       mutation({

--- a/src/pages/dashboard/projects.js
+++ b/src/pages/dashboard/projects.js
@@ -44,7 +44,6 @@ const Projects = ({
   history,
   projects,
   addProject,
-  setWarningModal,
   isOwner,
   isOrganizationOwner,
 }) => {

--- a/src/pages/dashboard/projects.js
+++ b/src/pages/dashboard/projects.js
@@ -140,7 +140,7 @@ const Projects = ({
   }
 
   const handleStopClick = id => {
-    handleStopProject({ id, dispatch })
+    handleStopProject({ id })
   }
 
   const closeModal = () => {

--- a/src/pages/dashboard/projects.js
+++ b/src/pages/dashboard/projects.js
@@ -269,7 +269,7 @@ const Projects = ({
                           font-size="0.8rem"
                           onClick={() => {
                             project.startedCollaborationFromId
-                              ? handleStopLiveshareClick({ project })
+                              ? handleStopProject({ isLiveshare: true })
                               : handleStopProject()
                           }}
                         >

--- a/src/pages/dashboard/projects.js
+++ b/src/pages/dashboard/projects.js
@@ -9,7 +9,6 @@ import {
   CONTINUE_PROJECT,
   SET_VISIBILITY,
   START_LIVE_SHARE,
-  STOP_LIVE_SHARE,
 } from 'queries'
 import { selectors, actions } from 'state'
 import { Modal, StroveButton, AddProjectProvider } from 'components'

--- a/src/pages/dashboard/projects.js
+++ b/src/pages/dashboard/projects.js
@@ -256,11 +256,7 @@ const Projects = ({
                           maxWidth="150px"
                           margin="0px 0px 5px 0px"
                           font-size="0.8rem"
-                          onClick={() => {
-                            project.startedCollaborationFromId
-                              ? handleStopProject({ isLiveshare: true })
-                              : handleStopProject()
-                          }}
+                          onClick={handleStopProject}
                         >
                           <IconDescription>Stop</IconDescription>
                           <ProjectActionIcon type="pause-circle" />

--- a/src/pages/runProject.js
+++ b/src/pages/runProject.js
@@ -1,6 +1,6 @@
 import React, { memo } from 'react'
 import styled from 'styled-components/macro'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
 import { selectors } from 'state'

--- a/src/pages/runProject.js
+++ b/src/pages/runProject.js
@@ -32,7 +32,6 @@ const StyledButton = styled(StroveButton)`
 
 const Run = ({ addProject, history }) => {
   const myOrganizations = useSelector(selectors.api.getOwnedOrganizations)
-  // const user = useSelector(selectors.api.getUser)
   const token = useSelector(selectors.getToken)
   const dispatch = useDispatch()
   const ownOrganization = myOrganizations?.[0]
@@ -43,21 +42,10 @@ const Run = ({ addProject, history }) => {
   /* Specify the route a user should be redirected to */
   const goBackTo = searchParams.get('goBackTo') || ''
 
-  const setEditedOrganization = ({ team }) => {
-    dispatch(
-      actions.editedOrganization.setEditedOrganization({
-        organization: myOrganizations[team.organizationId],
-        team,
-      })
-    )
-  }
-
   if (!token) {
     // If user is logged in, redirect to the embed project run
     history.push(`/embed/?repoUrl=${repoUrl}&goBackTo=${goBackTo}`)
   }
-  // eslint-disable-next-line
-  useEffect(() => setEditedOrganization({ team: lastTeam }), [])
 
   const onClick = () => {
     addProject({ link: repoUrl, teamId })

--- a/src/pages/runProject.js
+++ b/src/pages/runProject.js
@@ -1,9 +1,9 @@
-import React, { memo, useEffect } from 'react'
+import React, { memo } from 'react'
 import styled from 'styled-components/macro'
 import { useSelector, useDispatch } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
-import { selectors, actions } from 'state'
+import { selectors } from 'state'
 import {
   StroveButton,
   AddProjectProvider,
@@ -33,7 +33,6 @@ const StyledButton = styled(StroveButton)`
 const Run = ({ addProject, history }) => {
   const myOrganizations = useSelector(selectors.api.getOwnedOrganizations)
   const token = useSelector(selectors.getToken)
-  const dispatch = useDispatch()
   const ownOrganization = myOrganizations?.[0]
   const lastTeam = ownOrganization?.teams[ownOrganization.teams.length - 1]
   const teamId = lastTeam?.id

--- a/src/state/api/selectors.js
+++ b/src/state/api/selectors.js
@@ -24,11 +24,6 @@ export const getUserProjects = getApiData({
   defaultValue: [],
 })
 
-export const getMyTeams = getApiData({
-  fields: 'myTeams',
-  defaultValue: [],
-})
-
 export const getMyOrganizations = getApiData({
   fields: 'myOrganizations',
   defaultValue: [],

--- a/src/state/api/selectors.js
+++ b/src/state/api/selectors.js
@@ -87,11 +87,3 @@ export const getCurrentProject = createSelector(
     return projects.find(project => project?.userId === userId)
   }
 )
-
-export const getCurrentTeam = createSelector(
-  getCurrentProject,
-  getMyTeams,
-  (project, teams) => {
-    return teams.find(team => team.id === project.teamId)
-  }
-)

--- a/src/state/editedOrganization/selectors.js
+++ b/src/state/editedOrganization/selectors.js
@@ -7,4 +7,5 @@ export const getEditedOrganization = state =>
   getOwnedOrganizations(state)?.[0]
 
 export const getEditedTeam = state =>
-  getOr(null, ['editedOrganization', 'team'])(state)  || getOwnedOrganizations(state)[0]?.teams?.[0]
+  getOr(null, ['editedOrganization', 'team'])(state) ||
+  getOwnedOrganizations(state)[0]?.teams?.[0]

--- a/src/state/editedOrganization/selectors.js
+++ b/src/state/editedOrganization/selectors.js
@@ -7,4 +7,4 @@ export const getEditedOrganization = state =>
   getOwnedOrganizations(state)[0]
 
 export const getEditedTeam = state =>
-  getOr(null, ['editedOrganization', 'team'])(state) //  || getMyTeams(state)[0]
+  getOr(null, ['editedOrganization', 'team'])(state)  || getOwnedOrganizations(state)[0]?.teams?.[0]

--- a/src/state/editedOrganization/selectors.js
+++ b/src/state/editedOrganization/selectors.js
@@ -1,10 +1,10 @@
 import getOr from 'lodash/fp/getOr'
 
-import { getOwnedOrganizations, getMyTeams } from '../api/selectors'
+import { getOwnedOrganizations } from '../api/selectors'
 
 export const getEditedOrganization = state =>
   getOr(null, ['editedOrganization', 'organization'])(state) ||
   getOwnedOrganizations(state)[0]
 
 export const getEditedTeam = state =>
-  getOr(null, ['editedOrganization', 'team'])(state) || getMyTeams(state)[0]
+  getOr(null, ['editedOrganization', 'team'])(state) //  || getMyTeams(state)[0]

--- a/src/state/editedOrganization/selectors.js
+++ b/src/state/editedOrganization/selectors.js
@@ -4,7 +4,7 @@ import { getOwnedOrganizations } from '../api/selectors'
 
 export const getEditedOrganization = state =>
   getOr(null, ['editedOrganization', 'organization'])(state) ||
-  getOwnedOrganizations(state)[0]
+  getOwnedOrganizations(state)?.[0]
 
 export const getEditedTeam = state =>
   getOr(null, ['editedOrganization', 'team'])(state)  || getOwnedOrganizations(state)[0]?.teams?.[0]

--- a/src/state/editedOrganization/selectors.js
+++ b/src/state/editedOrganization/selectors.js
@@ -1,9 +1,10 @@
 import getOr from 'lodash/fp/getOr'
 
-import { getOwnedOrganizations } from '../api/selectors'
+import { getOwnedOrganizations, getMyTeams } from '../api/selectors'
 
 export const getEditedOrganization = state =>
   getOr(null, ['editedOrganization', 'organization'])(state) ||
   getOwnedOrganizations(state)[0]
 
-export const getEditedTeam = getOr(null, ['editedOrganization', 'team'])
+export const getEditedTeam = state =>
+  getOr(null, ['editedOrganization', 'team'])(state) || getMyTeams(state)[0]

--- a/src/state/editedOrganization/selectors.js
+++ b/src/state/editedOrganization/selectors.js
@@ -1,8 +1,9 @@
 import getOr from 'lodash/fp/getOr'
 
-export const getEditedOrganization = getOr(null, [
-  'editedOrganization',
-  'organization',
-])
+import { getMyOrganizations } from '../api/selectors'
+
+export const getEditedOrganization = state =>
+  getOr(null, ['editedOrganization', 'organization'])(state) ||
+  getMyOrganizations(state)
 
 export const getEditedTeam = getOr(null, ['editedOrganization', 'team'])

--- a/src/state/editedOrganization/selectors.js
+++ b/src/state/editedOrganization/selectors.js
@@ -1,9 +1,9 @@
 import getOr from 'lodash/fp/getOr'
 
-import { getMyOrganizations } from '../api/selectors'
+import { getOwnedOrganizations } from '../api/selectors'
 
 export const getEditedOrganization = state =>
   getOr(null, ['editedOrganization', 'organization'])(state) ||
-  getMyOrganizations(state)
+  getOwnedOrganizations(state)[0]
 
 export const getEditedTeam = getOr(null, ['editedOrganization', 'team'])

--- a/src/utils/createProject.js
+++ b/src/utils/createProject.js
@@ -127,6 +127,14 @@ const createProject = async ({
     }
 
     const { description, name /* add language and color */ } = repoData
+
+    console.log('{ repoLink, name, description, type, teamId }', {
+      repoLink,
+      name,
+      description,
+      type,
+      teamId,
+    })
     dispatch(
       mutation({
         name: 'addProject',

--- a/src/utils/createProject.js
+++ b/src/utils/createProject.js
@@ -126,15 +126,8 @@ const createProject = async ({
       dispatch(actions.incomingProject.setProjectIsBeingAdded())
     }
 
-    const { description, name /* add language and color */ } = repoData
+    const { description, name } = repoData
 
-    console.log('{ repoLink, name, description, type, teamId }', {
-      repoLink,
-      name,
-      description,
-      type,
-      teamId,
-    })
     dispatch(
       mutation({
         name: 'addProject',

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -1,9 +1,11 @@
 import { mutation, updateOrganizations } from 'utils'
 import { STOP_PROJECT } from 'queries'
 import store from 'store'
+import { selectors } from 'state'
 
 const handleStopProject = ({ id, dispatch }) => {
   const state = store.getState()
+  const currentProject = selectors.api.getCurrentProject(state)
 
   dispatch(
     mutation({

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -1,16 +1,25 @@
 import { mutation, updateOrganizations } from 'utils'
-import { STOP_PROJECT } from 'queries'
+import { STOP_PROJECT, STOP_LIVE_SHARE } from 'queries'
 import store from 'store'
 import { selectors } from 'state'
 
-const handleStopProject = ({ id }) => {
+const handleStopProject = ({ id, isLiveshare = false }) => {
   const state = store.getState()
   const dispatch = store.dispatch
   const currentProject = selectors.api.getCurrentProject(state)
 
-  console.log('currentProject', currentProject)
+  if (isLiveshare) {
+    return dispatch(
+      mutation({
+        name: 'stopLiveShare',
+        mutation: STOP_LIVE_SHARE,
+        variables: { projectId: currentProject.id },
+        onSuccessDispatch: updateOrganizations,
+      })
+    )
+  }
 
-  dispatch(
+  return dispatch(
     mutation({
       name: 'stopProject',
       mutation: STOP_PROJECT,

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -3,9 +3,12 @@ import { STOP_PROJECT } from 'queries'
 import store from 'store'
 import { selectors } from 'state'
 
-const handleStopProject = ({ id, dispatch }) => {
+const handleStopProject = ({ id }) => {
   const state = store.getState()
+  const dispatch = store.dispatch
   const currentProject = selectors.api.getCurrentProject(state)
+
+  console.log('currentProject', currentProject)
 
   dispatch(
     mutation({

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -3,10 +3,11 @@ import { STOP_PROJECT, STOP_LIVE_SHARE } from 'queries'
 import store from 'store'
 import { selectors } from 'state'
 
-const handleStopProject = ({ id, isLiveshare = false }) => {
+const handleStopProject = ({ id }) => {
   const state = store.getState()
   const dispatch = store.dispatch
   const currentProject = selectors.api.getCurrentProject(state)
+  const isLiveshare = currentProject.startedCollaborationFromId
   const projectId = id || currentProject?.id
 
   if (isLiveshare) {

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -17,7 +17,7 @@ const handleStopProject = ({ id, onSuccess } = {}) => {
         mutation: STOP_LIVE_SHARE,
         variables: { projectId },
         onSuccessDispatch: updateOrganizations,
-        onSuccess
+        onSuccess,
       })
     )
   }
@@ -29,6 +29,7 @@ const handleStopProject = ({ id, onSuccess } = {}) => {
       dataSelector: data => data,
       variables: { projectId },
       onSuccessDispatch: updateOrganizations,
+      onSuccess,
     })
   )
 }

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -7,13 +7,14 @@ const handleStopProject = ({ id, isLiveshare = false }) => {
   const state = store.getState()
   const dispatch = store.dispatch
   const currentProject = selectors.api.getCurrentProject(state)
+  const projectId = id || currentProject?.id
 
   if (isLiveshare) {
     return dispatch(
       mutation({
         name: 'stopLiveShare',
         mutation: STOP_LIVE_SHARE,
-        variables: { projectId: currentProject.id },
+        variables: { projectId },
         onSuccessDispatch: updateOrganizations,
       })
     )
@@ -24,7 +25,7 @@ const handleStopProject = ({ id, isLiveshare = false }) => {
       name: 'stopProject',
       mutation: STOP_PROJECT,
       dataSelector: data => data,
-      variables: { projectId: id || currentProject?.id },
+      variables: { projectId },
       onSuccessDispatch: updateOrganizations,
     })
   )

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -3,7 +3,7 @@ import { STOP_PROJECT, STOP_LIVE_SHARE } from 'queries'
 import store from 'store'
 import { selectors } from 'state'
 
-const handleStopProject = ({ id }) => {
+const handleStopProject = ({ id } = {}) => {
   const state = store.getState()
   const dispatch = store.dispatch
   const currentProject = selectors.api.getCurrentProject(state)

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -12,7 +12,7 @@ const handleStopProject = ({ id, dispatch }) => {
       name: 'stopProject',
       mutation: STOP_PROJECT,
       dataSelector: data => data,
-      variables: { projectId: id },
+      variables: { projectId: id || currentProject?.id },
       onSuccessDispatch: updateOrganizations,
     })
   )

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -1,7 +1,10 @@
 import { mutation, updateOrganizations } from 'utils'
 import { STOP_PROJECT } from 'queries'
+import store from 'store'
 
 const handleStopProject = ({ id, dispatch }) => {
+  const state = store.getState()
+
   dispatch(
     mutation({
       name: 'stopProject',

--- a/src/utils/stopProject.js
+++ b/src/utils/stopProject.js
@@ -3,7 +3,7 @@ import { STOP_PROJECT, STOP_LIVE_SHARE } from 'queries'
 import store from 'store'
 import { selectors } from 'state'
 
-const handleStopProject = ({ id } = {}) => {
+const handleStopProject = ({ id, onSuccess } = {}) => {
   const state = store.getState()
   const dispatch = store.dispatch
   const currentProject = selectors.api.getCurrentProject(state)
@@ -17,6 +17,7 @@ const handleStopProject = ({ id } = {}) => {
         mutation: STOP_LIVE_SHARE,
         variables: { projectId },
         onSuccessDispatch: updateOrganizations,
+        onSuccess
       })
     )
   }


### PR DESCRIPTION
That's a cool one

We no longer need dispatch and projectId in handleProjectStop, this removes a bunch of selectors here and there
handleProjectStop now handles liveshare as well

Embed projects are stopped by default when we run a new one

There's an attempt to make sure embeds do not have a dashboard link in the header

Cloning project with # works
Cloning a project with # also automatically stops a previous one

editedTeam selector was added for less repeated code AND no redundant rerenders

Project modals are simplified

We display a nice massage when a project is being stopped